### PR TITLE
Update development tools and dependencies

### DIFF
--- a/mcp/server/tool.go
+++ b/mcp/server/tool.go
@@ -10,6 +10,7 @@ import (
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	llm "github.com/mutablelogic/go-llm"
 	schema "github.com/mutablelogic/go-llm/kernel/schema"
+	jsonschema "github.com/mutablelogic/go-server/pkg/jsonschema"
 	types "github.com/mutablelogic/go-server/pkg/types"
 	trace "go.opentelemetry.io/otel/trace"
 )
@@ -44,6 +45,9 @@ func (s *Server) RemoveTools(names ...string) {
 func sdkToolFromTool(t llm.Tool, tracer trace.Tracer) (*sdkmcp.Tool, sdkmcp.ToolHandler, error) {
 	// Build input schema — SDK accepts any JSON-marshalable value.
 	inputSchema := t.InputSchema()
+	if inputSchema == nil {
+		inputSchema = jsonschema.MustFor[struct{}]()
+	}
 	var err error
 	inputSchemaRaw, err := json.Marshal(inputSchema)
 	if err != nil {

--- a/mcp/server/tool_test.go
+++ b/mcp/server/tool_test.go
@@ -10,6 +10,7 @@ import (
 
 	// Packages
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+	llm "github.com/mutablelogic/go-llm"
 	homeassistant "github.com/mutablelogic/go-llm/homeassistant/connector"
 	schema "github.com/mutablelogic/go-llm/kernel/schema"
 	mock "github.com/mutablelogic/go-llm/mcp/mock"
@@ -282,6 +283,29 @@ func TestAddToolsBadInputSchema(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for tool with unmarshalable InputSchema, got nil")
+	}
+}
+
+type nilInputSchemaTool struct{}
+
+func (nilInputSchemaTool) Name() string                    { return "nil_input_schema" }
+func (nilInputSchemaTool) Description() string             { return "tool with nil input schema" }
+func (nilInputSchemaTool) InputSchema() *jsonschema.Schema { return nil }
+func (nilInputSchemaTool) OutputSchema() *jsonschema.Schema {
+	return nil
+}
+func (nilInputSchemaTool) Meta() llm.ToolMeta { return llm.ToolMeta{} }
+func (nilInputSchemaTool) Run(context.Context, json.RawMessage) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+func TestAddToolsNilInputSchemaDefaultsToEmptyObject(t *testing.T) {
+	srv, err := server.New("test-server", "1.0.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.AddTools(nilInputSchemaTool{}); err != nil {
+		t.Fatalf("expected nil input schema to be accepted, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This pull request improves the handling of tools with a `nil` input schema in the server code, ensuring they are accepted and default to an empty object schema. It also adds a test to verify this behavior.

**Input schema handling improvements:**

* Updated `sdkToolFromTool` in `mcp/server/tool.go` to default any `nil` input schema to an empty object schema using `jsonschema.MustFor[struct{}]()`, ensuring all tools have a valid input schema.
* Added the `jsonschema` import to support the new defaulting behavior.

**Testing enhancements:**

* Added a new test tool, `nilInputSchemaTool`, and a corresponding test case, `TestAddToolsNilInputSchemaDefaultsToEmptyObject`, in `mcp/server/tool_test.go` to verify that tools with a `nil` input schema are accepted without error.
* Added the missing `llm` import in the test file to support the new test tool implementation.